### PR TITLE
Using tokio tracing for structured logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,8 +199,9 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_yaml 0.9.13",
- "simple_logger",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1240,9 +1241,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "opaque-debug"
@@ -1413,9 +1414,9 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
@@ -2108,23 +2109,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "simple_logger"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48047e77b528151aaf841a10a9025f9459da80ba820e425ff7eb005708a76dc7"
-dependencies = [
- "atty",
- "log",
- "winapi",
 ]
 
 [[package]]
@@ -2135,9 +2134,9 @@ checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"
-version = "1.7.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"
@@ -2193,9 +2192,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.95"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2240,6 +2239,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -2448,9 +2456,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.29"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "log",
@@ -2461,9 +2469,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.18"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2472,11 +2480,36 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.21"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
- "lazy_static",
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+dependencies = [
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -2607,6 +2640,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 
 [dependencies]
 log = "0.4.17"
-simple_logger = {version = "2.3.0", default-features = false }
 kube = {version = "0.74.0", features = ["derive", "admission", "runtime"]}
 k8s-openapi = { version = "0.15.0", default-features = false, features = ["v1_19"] }
 schemars = "0.8.10"
@@ -29,6 +28,8 @@ prometheus = {version = "0.13.2", features = ["process"]}
 json-patch = "0.2.6"
 exponential-backoff = "1.1.0"
 reqwest = {version="0.11.11"}
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.16", default-features = false, features = ["fmt", "json"] } 
 
 
 [profile.release]

--- a/charts/bridgekeeper/templates/deployment.yaml
+++ b/charts/bridgekeeper/templates/deployment.yaml
@@ -60,6 +60,10 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
+            {{- if .Values.bridgekeeper.logging.mode }}
+            - name: LOGGING_MODE
+              value: {{ .Values.bridgekeeper.logging.mode }}
+            {{- end }}
           volumeMounts:
             - mountPath: /certs
               name: cert

--- a/charts/bridgekeeper/values.yaml
+++ b/charts/bridgekeeper/values.yaml
@@ -73,6 +73,9 @@ bridgekeeper:
   # Timeout in seconds for admission requests (if strictAdmission false requests will be allowed after timeout, otherwise rejected), defaults to 5 seconds
   # Maximum allowed value is 30 seconds
   admissionTimeoutSeconds: ""
+  # Configures the logging type. Available options: plain | json
+  logging:
+    mode: plain
   audit: 
     # Set this to true if you want bridgekeeper to run regular audits
     enabled: false

--- a/src/api.rs
+++ b/src/api.rs
@@ -8,6 +8,7 @@ use kube::{
 use lazy_static::lazy_static;
 use prometheus::{register_counter_vec, CounterVec, Encoder, TextEncoder};
 use rocket::http::ContentType;
+use rocket::log::LogLevel;
 use rocket::response::Responder;
 use rocket::{config::TlsConfig, serde::json::Json, Config, State};
 use std::convert::TryInto;
@@ -137,6 +138,7 @@ pub async fn server(cert: CertKeyPair, evaluator: PolicyEvaluatorRef) {
             cert.cert.as_bytes(),
             cert.key.as_bytes(),
         )),
+        log_level: LogLevel::Off,
         ..Config::default()
     };
 

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -12,6 +12,7 @@ use prometheus::{register_counter_vec, CounterVec};
 use pyo3::prelude::*;
 use serde_derive::Serialize;
 use std::sync::Arc;
+use tracing::{info, warn};
 
 lazy_static! {
     static ref MATCHED_POLICIES: CounterVec = register_counter_vec!(
@@ -120,7 +121,7 @@ impl PolicyEvaluator {
                 MATCHED_POLICIES
                     .with_label_values(&[value.name.as_str()])
                     .inc();
-                log::info!(
+                info!(
                     "Object {}.{}/{}/{} matches policy {}",
                     gvk.kind,
                     gvk.group,
@@ -161,12 +162,12 @@ impl PolicyEvaluator {
                         reason: res.1.clone(),
                     },
                 })
-                .unwrap_or_else(|err| log::warn!("Could not send event: {:?}", err));
+                .unwrap_or_else(|err| warn!("Could not send event: {:?}", err));
             if res.0 {
                 POLICY_EVALUATIONS_SUCCESS
                     .with_label_values(&[value.name.as_str()])
                     .inc();
-                log::info!("Policy '{}' evaluates to {}", value.name, res.0);
+                info!("Policy '{}' evaluates to {}", value.name, res.0);
                 if let Some(warning) = res.1 {
                     warnings.push(warning);
                 }
@@ -175,7 +176,7 @@ impl PolicyEvaluator {
                     .with_label_values(&[value.name.as_str()])
                     .inc();
                 let reason = res.1.unwrap_or_else(|| "-".to_string());
-                log::info!(
+                info!(
                     "Policy '{}' evaluates to {} with message '{}'",
                     value.name,
                     res.0,

--- a/src/events.rs
+++ b/src/events.rs
@@ -8,6 +8,7 @@ use kube::{
 };
 use tokio::sync::mpsc::{self, UnboundedSender};
 use tokio::task;
+use tracing::warn;
 
 pub type EventSender = UnboundedSender<PolicyEvent>;
 
@@ -62,7 +63,7 @@ pub fn init_event_watcher(client: &Client) -> EventSender {
                 }
             }
             if let Err(err) = events_api.create(&PostParams::default(), &kube_event).await {
-                log::warn!(
+                warn!(
                     "Could not create event for policy {}. Reason: {}",
                     event
                         .policy_reference

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use argh::FromArgs;
+use tracing::{Level};
 
 mod api;
 mod audit;
@@ -32,16 +33,16 @@ enum CommandEnum {
 #[tokio::main(flavor = "multi_thread")]
 async fn main() {
     let args: MainArgs = argh::from_env();
+
     let log_level = match args.command {
-        CommandEnum::Server(_) => log::LevelFilter::Info,
-        _ => log::LevelFilter::Error,
+        CommandEnum::Server(_) => Level::INFO,
+        _ => Level::ERROR,
     };
-    simple_logger::SimpleLogger::new()
-        .with_level(log_level)
-        .with_module_level("rocket::server", log::LevelFilter::Warn)
-        .with_module_level("_", log::LevelFilter::Warn)
-        .init()
-        .expect("failed to initialize logging");
+    tracing_subscriber::fmt()
+        .json()
+        .with_max_level(log_level)
+        .init();
+    
     match args.command {
         CommandEnum::Server(args) => server::run(args).await,
         CommandEnum::Init(args) => helper::init::run(args).await,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use argh::FromArgs;
-use tracing::{Level};
+use tracing::Level;
 
 mod api;
 mod audit;
@@ -38,11 +38,20 @@ async fn main() {
         CommandEnum::Server(_) => Level::INFO,
         _ => Level::ERROR,
     };
-    tracing_subscriber::fmt()
-        .json()
-        .with_max_level(log_level)
-        .init();
-    
+
+    let log_mode = std::env::var("LOGGING_MODE").unwrap_or_else(|_| "plain".into());
+
+    if log_mode.to_lowercase().eq("json") {
+        tracing_subscriber::fmt()
+            .json()
+            .with_max_level(log_level)
+            .init();
+    } else {
+        tracing_subscriber::fmt()
+            .with_max_level(log_level)
+            .init();
+    }
+
     match args.command {
         CommandEnum::Server(args) => server::run(args).await,
         CommandEnum::Init(args) => helper::init::run(args).await,

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -11,6 +11,7 @@ use kube::{
     Client,
 };
 use tokio::task;
+use tracing::warn;
 
 pub struct Manager {
     k8s_client: Client,
@@ -42,7 +43,7 @@ impl Manager {
                             policy_reference: ref_info,
                             event_data: PolicyEventData::Loaded,
                         })
-                        .unwrap_or_else(|err| log::warn!("Could not send event: {:?}", err));
+                        .unwrap_or_else(|err| warn!("Could not send event: {:?}", err));
                 }
             }
         }
@@ -71,7 +72,7 @@ impl Manager {
                                         event_data: PolicyEventData::Loaded,
                                     })
                                     .unwrap_or_else(|err| {
-                                        log::warn!("Could not send event: {:?}", err)
+                                        warn!("Could not send event: {:?}", err)
                                     });
                             }
                         }

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -8,6 +8,7 @@ use prometheus::{register_gauge, Gauge};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use tracing::info;
 
 lazy_static! {
     static ref ACTIVE_POLICIES: Gauge =
@@ -120,7 +121,7 @@ impl PolicyStore {
         if let Some(existing_policy_info) = self.policies.get(&name) {
             if existing_policy_info.policy != policy.spec {
                 let policy_info = PolicyInfo::new(name.clone(), policy.spec, ref_info.clone());
-                log::info!("Policy '{}' updated", name);
+                info!("Policy '{}' updated", name);
                 self.policies.insert(name, policy_info);
                 Some(ref_info)
             } else {
@@ -128,7 +129,7 @@ impl PolicyStore {
             }
         } else {
             let policy_info = PolicyInfo::new(name.clone(), policy.spec, ref_info.clone());
-            log::info!("Policy '{}' added", name);
+            info!("Policy '{}' added", name);
             self.policies.insert(name, policy_info);
             ACTIVE_POLICIES.inc();
             Some(ref_info)
@@ -137,7 +138,7 @@ impl PolicyStore {
 
     pub fn remove_policy(&mut self, policy: Policy) {
         let name = policy.metadata.name.expect("name is always set");
-        log::info!("Policy '{}' removed", name);
+        info!("Policy '{}' removed", name);
         self.policies.remove(&name);
         ACTIVE_POLICIES.dec();
     }


### PR DESCRIPTION
The library "tracing" maintained by the same people as "tokio" allows for events (e2e tracing etc) but also logging. Using a tracing-subscriber, the log channel can be subscribed to and passed on to stdout or similar 👍  the current implementation disables rocket logs, since it seems like Rocket doesn't support custom logging (correct me if I'm wrong).

I have another implementation laying around using the library "slog", which seems to be one of the most popular logging libraries in the Rust context, however its not a perfect fit for multithreaded / parallel code - however we can take a look at the  other implementation, if this one isn't sufficient.

This screenshot is the result of this test code:
```rust
use tracing::info;
info!("This is an info log");
```

<img width="785" alt="image" src="https://user-images.githubusercontent.com/25712873/210003837-7a90dbe1-34ee-4279-9780-75b64b1c9506.png">
